### PR TITLE
Providing metric prefix for circuit metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,4 @@ new PrometheusMetrics(options)
 |`circuits`                |A list or individual circuit breaker to create metrics for              |No circuits                                                                                            |
 |`registry`                |An existing registry to use for prometheus metrics                      |`undefined` - The default prometheus registry will be used and default system metrics will be collected|
 |`exposePerformanceMetrics`|Measure the performance of breakers and report them through the registry|true                                                                                                   |
+|`metricPrefix`|Prefix for circuit breakers metrics name|any string                                                                                                 |

--- a/index.js
+++ b/index.js
@@ -13,10 +13,11 @@ const client = require('prom-client');
 class PrometheusMetrics {
   constructor (options = {}) {
     this._registry = options.registry || client.register;
+    this._metricPrefix = options.metricPrefix || ``;
     this._client = client;
     this._options = options;
     this._counter = new this._client.Counter({
-      name: `circuit`,
+      name: `${this._metricPrefix}circuit`,
       help: `A count of all circuit' events`,
       registers: [this._registry],
       labelNames: ['name', 'event']
@@ -24,7 +25,7 @@ class PrometheusMetrics {
 
     if (this.exposePerformanceMetrics()) {
       this._summary = new this._client.Summary({
-        name: `circuit_perf`,
+        name: `${this._metricPrefix}circuit_perf`,
         help: `A summary of all circuit's events`,
         registers: [this._registry],
         labelNames: ['name', 'event']
@@ -33,7 +34,10 @@ class PrometheusMetrics {
 
     if (!options.registry) {
       this.interval = this._client
-        .collectDefaultMetrics({ prefix: 'opossum_', timeout: 5000 });
+        .collectDefaultMetrics({
+          prefix: `${this._metricPrefix}opossum_`,
+          timeout: 5000
+        });
     }
 
     if (options.circuits) {

--- a/test/prometheus-test.js
+++ b/test/prometheus-test.js
@@ -30,17 +30,18 @@ test('The factory function accept no parameter', t => {
   t.end();
 });
 
-test('The factory function takes an object instead of just an Array', async t => {
-  t.plan(3);
-  const c1 = new CircuitBreaker(passFail, { name: 'fred' });
-  const prometheus = new PrometheusMetrics({ circuits: c1 });
-  await c1.fire(1);
-  t.equal(c1.name, 'fred');
-  t.ok(/circuit.*fred/.test(prometheus.metrics));
-  t.ok(/circuit_perf.*fred/.test(prometheus.metrics));
-  prometheus.clear();
-  t.end();
-});
+test('The factory function takes an object instead of just an Array',
+  async t => {
+    t.plan(3);
+    const c1 = new CircuitBreaker(passFail, { name: 'fred' });
+    const prometheus = new PrometheusMetrics({ circuits: c1 });
+    await c1.fire(1);
+    t.equal(c1.name, 'fred');
+    t.ok(/circuit.*fred/.test(prometheus.metrics));
+    t.ok(/circuit_perf.*fred/.test(prometheus.metrics));
+    prometheus.clear();
+    t.end();
+  });
 
 test('The factory function provides access to metrics for all circuits',
   async t => {
@@ -316,6 +317,27 @@ test('Performance metrics are created when enabled in options',
     t.equal(c1.name, 'fred');
     t.ok(/circuit.*fred/.test(prometheus.metrics));
     t.ok(/circuit_perf.*fred/.test(prometheus.metrics));
+    prometheus.clear();
+    t.end();
+  });
+
+test('The factory function provides metric prefix and it append to metric name',
+  async t => {
+    t.plan(6);
+    const c1 = new CircuitBreaker(passFail, { name: 'fred' });
+    const c2 = new CircuitBreaker(passFail, { name: 'bob' });
+    const prometheus = new PrometheusMetrics({
+      circuits: [c1, c2],
+      metricPrefix: 'some_prefix_'
+    });
+    await c1.fire(1);
+    await c2.fire(1);
+    t.equal(c1.name, 'fred');
+    t.equal(c2.name, 'bob');
+    t.ok(/some_prefix_circuit.*fred/.test(prometheus.metrics));
+    t.ok(/some_prefix_circuit_perf.*fred/.test(prometheus.metrics));
+    t.ok(/some_prefix_circuit.*bob/.test(prometheus.metrics));
+    t.ok(/some_prefix_circuit_perf.*bob/.test(prometheus.metrics));
     prometheus.clear();
     t.end();
   });


### PR DESCRIPTION
This pull request provides an option to have a base prefix for the metrics generated, in this case its possible to send it from any different applications to the same grafana without conflicting the information.
I also have fixed some lint problems.