### PR TITLE
chore: use Coveralls action

### DIFF
--- a/.github/workflows/nodejs-ci-action.yml
+++ b/.github/workflows/nodejs-ci-action.yml
@@ -23,5 +23,19 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - run: npm ci
     - run: npm test
-    - run: echo 'repo_token:' ${{ secrets.COVERALLS_GITHUB_TOKEN }} > ./.coveralls.yml
-    - run: node_modules/nyc/bin/nyc.js report --reporter=text-lcov | node_modules/coveralls/bin/coveralls.js
+    - run: node_modules/nyc/bin/nyc.js report --reporter=lcovonly
+    - name: Coveralls Parallel
+      uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.github_token }}
+        flag-name: run-${{ matrix.node-version }}
+        parallel: true
+  finish:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Coveralls Finished
+      uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.github_token }}
+        parallel-finished: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1188,27 +1188,6 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
-    "coveralls": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.1.0.tgz",
-      "integrity": "sha512-sHxOu2ELzW8/NC1UP5XVLbZDzO4S3VxfFye3XYCznopHy02YjNkHcj5bKaVw2O7hVaBdBjEdQGpie4II1mWhuQ==",
-      "dev": true,
-      "requires": {
-        "js-yaml": "^3.13.1",
-        "lcov-parse": "^1.0.0",
-        "log-driver": "^1.2.7",
-        "minimist": "^1.2.5",
-        "request": "^2.88.2"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
-        }
-      }
-    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "author": "Red Hat, Inc.",
   "license": "Apache-2.0",
   "devDependencies": {
-    "coveralls": "^3.1.0",
     "husky": "^6.0.0",
     "nyc": "^15.1.0",
     "opossum": "^5.1.3",


### PR DESCRIPTION
Switch to use the Coveralls GitHub action rather than the module as
it works better with pull requests from forks.